### PR TITLE
feat: expose option to add abort event handler

### DIFF
--- a/__tests__/Upload.jsdom.test.ts
+++ b/__tests__/Upload.jsdom.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import FD from 'form-data';
+import { Upload } from '../src';
+
+it('aborts the process', async () => {
+  const formData = new FD();
+  formData.append('file', Buffer.from('test'), {
+    filename: 'test',
+  });
+  const upload = new Upload({
+    url: 'https://httpbin.org/post',
+    // @ts-ignore
+    form: formData,
+  });
+
+  let progress = 0;
+  const abortHandler = jest.fn(() => {});
+  const progressHandler = jest.fn(p => (progress = p));
+
+  upload.on('state', () => {
+    if (upload.state === 'aborted') abortHandler();
+  });
+  upload.on('progress', progressHandler);
+  upload.upload();
+
+  upload.abort();
+  expect(abortHandler).toBeCalled();
+  expect(progress).not.toBe(1);
+  expect(upload.state).toBe('aborted');
+});


### PR DESCRIPTION
This PR adds another state (`"aborted"`) to the list of states, and allow for users to opt-in to abort event by listening to the `state` event and `state === 'aborted'`, cc @mat-sz 