### PR TITLE
Add status and xhr to response

### DIFF
--- a/src/Upload.ts
+++ b/src/Upload.ts
@@ -10,6 +10,8 @@ export interface UploadOptions {
 
 export interface UploadResponse {
   data?: string | ArrayBuffer | Blob;
+  xhr?: XMLHttpRequest;
+  status?: Number;
   headers?: Record<string, string | string[] | undefined>;
 }
 
@@ -129,6 +131,8 @@ export class Upload {
               headers[split[0].trim()] = split[1].trim();
             }
             response.headers = headers;
+            response.status = this.xhr.status;
+            response.xhr = this.xhr;
 
             switch (this.xhr.responseType) {
               case 'json':


### PR DESCRIPTION
There's currently no way to see whether the response was successful or not.

This adds `status` and `xhr` to the response object.

```js
upload.upload().then(response => {
  if (response.status === 200) {
    // upload successful
  } else {
    // something went wrong
  }
});
```
